### PR TITLE
fixed broken dependency on elixir-datetime

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,6 +16,6 @@ defmodule DateFmt.Mixfile do
   # Returns the list of dependencies in the format:
   # { :foobar, "~> 0.1", git: "https://github.com/elixir-lang/foobar.git" }
   defp deps do
-    [{:"elixir-date", github: "alco/elixir-datetime"}]
+    [{:"elixir-datetime", github: "alco/elixir-datetime"}]
   end
 end


### PR DESCRIPTION
The mix file was referring to the incorrect module name elixir-date, when it should have been elixir-datetime, causing dependencies to fail.
